### PR TITLE
Add test script for TravisCI

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+set -x
+
+for source in ./*/*.d
+do
+    dub run -b unittest --compiler=$DC --single $source
+    dub build -b debug --compiler=$DC --single $source
+    dub build -b release --compiler=$DC --single $source
+done

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,9 @@ os:
   - linux
   - osx
 
+matrix:
+  exclude:
+    - d: gdc
+      os: osx
+
 script: bash ./.travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
+sudo: false
 language: d
 
 # latest dmd, gdc and ldc
 d:
-  -dmd
-  -gdc
-  -ldc
+  - dmd
+  - gdc
+  - ldc
+
+os:
+  - linux
+  - osx
+
+script: bash ./.travis.sh


### PR DESCRIPTION
Tests on both Linux and OS X, builds `debug` and `release` configurations, and runs unit tests.
